### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/build-and-draft-release.yaml
+++ b/.github/workflows/build-and-draft-release.yaml
@@ -1,0 +1,39 @@
+name: Build and Draft Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: The released version without 'v'. For example, 1.0.0.
+permissions:
+  contents: write
+env:
+  VERSION: ${{ github.event.inputs.version }}
+jobs:
+  draft_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21.x"
+      - name: Set up Git name and email
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+      - name: Build assets and draft release
+        run: bash ./scripts/draftrelease.bash
+        env:
+          GH_TOKEN:  ${{ secrets.GITHUB_TOKEN }}
+          WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_NOTIFICATION_WEBHOOK }}
+          RELEASE_MINISIGN_PRIVATE_KEY: ${{secrets.RELEASE_MINISIGN_PRIVATE_KEY}}
+          RELEASE_MINISIGN_PRIVATE_KEY_PASSWORD: ${{secrets.RELEASE_MINISIGN_PRIVATE_KEY_PASSWORD}}
+      - name: Unset keys
+        if: ${{ always() }}
+        run: |
+          unset RELEASE_MINISIGN_PRIVATE_KEY
+          unset RELEASE_MINISIGN_PRIVATE_KEY_PASSWORD

--- a/.github/workflows/build-and-draft-release.yaml
+++ b/.github/workflows/build-and-draft-release.yaml
@@ -5,10 +5,14 @@ on:
       version:
         type: string
         description: The released version without 'v'. For example, 1.0.0.
+  # TODO: delete
+  push:
+    branches: [osun/add-release-workflow]
 permissions:
   contents: write
 env:
-  VERSION: ${{ github.event.inputs.version }}
+  # TODO: remove 0.1.0
+  VERSION: ${{ github.event.inputs.version || '0.1.0' }}
 jobs:
   draft_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-draft-release.yaml
+++ b/.github/workflows/build-and-draft-release.yaml
@@ -5,14 +5,10 @@ on:
       version:
         type: string
         description: The released version without 'v'. For example, 1.0.0.
-  # TODO: delete
-  push:
-    branches: [osun/add-release-workflow]
 permissions:
   contents: write
 env:
-  # TODO: remove 0.1.0
-  VERSION: ${{ github.event.inputs.version || '0.1.0' }}
+  VERSION: ${{ github.event.inputs.version }}
 jobs:
   draft_release:
     runs-on: ubuntu-latest

--- a/scripts/draftrelease.bash
+++ b/scripts/draftrelease.bash
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+DIR="$(CDPATH= cd "$(dirname "${0}")/.." && pwd)"
+echo "DIR is $DIR"
+cd "${DIR}"
+
+# We already have set -u, but want to fail early if a required variable is not set.
+: ${RELEASE_MINISIGN_PRIVATE_KEY}
+: ${RELEASE_MINISIGN_PRIVATE_KEY_PASSWORD}
+# However, if you are already logged in for GitHub CLI locally, you can remove this line when running it locally.
+: ${GH_TOKEN}
+
+if [[ "${VERSION}" == v* ]]; then
+  echo "error: VERSION ${VERSION} must not start with 'v'" >&2
+  exit 1
+fi
+
+make release
+unset RELEASE_MINISIGN_PRIVATE_KEY
+unset RELEASE_MINISIGN_PRIVATE_KEY_PASSWORD
+
+
+# The second v${VERSION} is the tag, see https://cli.github.com/manual/gh_release_create
+url=$(gh release create --draft --notes "replace me" --title "v${VERSION}" "v${VERSION}" .build/release/bufisk/assets/*)
+
+echo "Release ${VERSION} has been drafted: ${url}"


### PR DESCRIPTION
This PR adds a new workflow `Build and Draft Release`, taking an input version, building the assets and drafting a release with tag.

To make a release:
1. Go to Actions, run this workflow with an input, say `1.2.3`
2. The workflow builds the assets and draft a release, with tag `v1.2.3`
3. Go to releases (from the web UI), edit release notes and click Publish.