### PR TITLE
Update go and golangci-lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.20.x,1.21.x,1.22.x]
+        go-version: [1.21.x,1.22.x,1.23.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -32,5 +32,5 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.22.x'
+        if: matrix.go-version == '1.23.x'
         run: make checkgenerate && make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-run:
-  skip-dirs-use-default: false
 linters-settings:
   errcheck:
     check-type-assertions: true
@@ -24,34 +22,27 @@ linters:
   disable:
     - cyclop            # covered by gocyclo
     - depguard          # unnecessary for small libraries
-    - deadcode          # abandoned
-    - exhaustivestruct  # replaced by exhaustruct
+    - execinquery       # deprecated in golangci v1.58 
     - funlen            # rely on code review to limit function length
     - gochecknoglobals  # we have very limited globals in bufisk
     - gocognit          # dubious "cognitive overhead" quantification
     - gofumpt           # prefer standard gofmt
     - goimports         # rely on gci instead
-    - golint            # deprecated by Go team
-    - gomnd             # some unnamed constants are okay
-    - ifshort           # deprecated by author
+    - gomnd             # deprecated in golangci v1.58 in favor of mnd
+    - mnd               # some unnamed constants are okay
     - inamedparam       # convention is not followed
-    - interfacer        # deprecated by author
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
     - maintidx          # covered by gocyclo
-    - maligned          # readability trumps efficient struct packing
     - nlreturn          # generous whitespace violates house style
     - nonamedreturns    # named returns are fine; it's *bare* returns that are bad
-    - nosnakecase       # deprecated in https://github.com/golangci/golangci-lint/pull/3065
     - protogetter       # too many false positives
-    - scopelint         # deprecated by author
-    - structcheck       # abandoned
     - testpackage       # internal tests are fine
-    - varcheck          # abandoned
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
 issues:
+  exclude-dirs-use-default: false
   exclude:
     # Don't ban use of fmt.Errorf to create new errors, but the remaining
     # checks from err113 are useful.
-    - "err113: do not define dynamic errors.*"
+    - "do not define dynamic errors.*"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,8 +20,10 @@ linters-settings:
 linters:
   enable-all: true
   disable:
+    - copyloopvar       # only valid for go v1.22 and above
     - cyclop            # covered by gocyclo
     - depguard          # unnecessary for small libraries
+    - exportloopref     # deprecated in golangci v1.60.2
     - execinquery       # deprecated in golangci v1.58 
     - funlen            # rely on code review to limit function length
     - gochecknoglobals  # we have very limited globals in bufisk
@@ -31,6 +33,7 @@ linters:
     - gomnd             # deprecated in golangci v1.58 in favor of mnd
     - mnd               # some unnamed constants are okay
     - inamedparam       # convention is not followed
+    - intrange          # only valid for go v1.22 and above
     - ireturn           # "accept interfaces, return structs" isn't ironclad
     - lll               # don't want hard limits for line length
     - maintidx          # covered by gocyclo

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.3
 
 $(BIN)/minisign: Makefile
 	@mkdir -p $(@D)

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.0
 
 $(BIN)/minisign: Makefile
 	@mkdir -p $(@D)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/bufisk
 
-go 1.20
+go 1.22
 
 require aead.dev/minisign v0.2.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bufbuild/bufisk
 
-go 1.22
+go 1.21
 
 require aead.dev/minisign v0.2.1
 


### PR DESCRIPTION
Now that a new version of Go has been released, this bumps the versions used in this repo and drops support for Go v1.20.

This also updates golangci-lint to the latest, which called for some config changes to eliminate warnings.